### PR TITLE
update content license to CC-BY-4.0

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
                 <div class="copyright">
                     <p class="text-justify">
                         <p>Copyright &copy; 2023-{{ 'now' | date: "%Y" }} Authors of <a href="https://github.com/CRESYM/colib0.github.io">Collaborative Open-Source Dynamic Simulation Library</a>.
-                            Unless otherwise indicated, content is licensed under <a rel="license" href="https://creativecommons.org/publicdomain/zero/1.0/">CC0 1.0</a>.
+                            Unless otherwise indicated, content is licensed under <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">CC-BY-4.0</a>.
                         </p>
                     </p>
                 </div>


### PR DESCRIPTION
updated footer file to change the link pointing to CC-BY-4.0